### PR TITLE
[Refactor] separate summary request and pull request process

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -35,12 +35,28 @@ export interface BlogPost {
   title: string;
   url: string;
   content: string;
-  summary: string | null;
-  // TODO: 추후 PR 이력 관리 추가
-  is_pull_requested: boolean | null;
   published_at: string;
   guid: string;
   created_at: string;
   updated_at: string;
   member?: Member;
+}
+
+export interface PostSummary {
+  id: string;
+  blog_post_id: string;
+  summary: string;
+  is_summarized: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PullRequest {
+  id: string;
+  blog_post_id: string;
+  study_id: string;
+  is_opened: boolean;
+  pr_url: string | null;
+  created_at: string;
+  updated_at: string;
 }


### PR DESCRIPTION
1. Post Summary와 Pull Request 스키마, 타입 추가
2. blog_post가 가지고 있던 요약 정보와, pull request에 대한 정보를 이제 두 테이블에서 나눠서 보관
3. 변경에 맞게 API 동작 수정
    - blog_post parsing시 summary 정보와 pr 관련 정보를 DB에 저장한다.
    - 요약, pr open 이후 두 데이터에서 요약 여부, PR Open 여부를 Update한다.